### PR TITLE
feature: dictionaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ zig build -Doptimize=ReleaseFast
 
 ### accumulator
 Like JavaScript, honey supports `let` and `const` bindings. It also supports the continue expression (`i += 1` in this case) from Zig.
-```js
+```zig
 
 const ITERATIONS = 100;
 

--- a/src/builtins.zig
+++ b/src/builtins.zig
@@ -130,6 +130,20 @@ pub fn to_string(vm: *Vm, args: []const Value) !?Value {
     return try vm.createString(stream.getWritten());
 }
 
+/// Returns the length of a string, list, or dictionary.
+pub fn len(_: *Vm, args: []const Value) !?Value {
+    if (args.len != 1) {
+        return error.InvalidNumberOfArguments;
+    }
+
+    return switch (args[0]) {
+        .string => |string| .{ .number = @floatFromInt(string.len) },
+        .list => |list| .{ .number = @floatFromInt(list.count()) },
+        .dict => |dict| .{ .number = @floatFromInt(dict.count()) },
+        else => error.InvalidArgument,
+    };
+}
+
 pub fn memory(vm: *Vm, args: []const Value) !?Value {
     if (args.len != 0) {
         return error.InvalidNumberOfArguments;

--- a/src/compiler/ARCHITECTURE.md
+++ b/src/compiler/ARCHITECTURE.md
@@ -7,10 +7,11 @@
 | `return`        | 0x00   | void     |
 | `const`         | 0x01   | u16      |
 | `list`          | 0x02   | u16      |
-| `pop`           | 0x03   | void     |
-| `jump`          | 0x04   | u16      |
-| `jump_if_false` | 0x05   | u16      |
-| `loop`          | 0x06   | u16      |
+| `dict`          | 0x03   | u16      |
+| `pop`           | 0x04   | void     |
+| `jump`          | 0x05   | u16      |
+| `jump_if_false` | 0x06   | u16      |
+| `loop`          | 0x07   | u16      |
 | `true`          | 0x10   | void     |
 | `false`         | 0x11   | void     |
 | `null`          | 0x12   | void     |
@@ -40,3 +41,6 @@
 | `get_local`     | 0x71   | u16      |
 | `set_index`     | 0x72   | void     |
 | `get_index`     | 0x73   | void     |
+| `set_member`    | 0x74   | void     |
+| `get_member`    | 0x75   | void     |
+| `declare_key`   | 0x80   | u16      |

--- a/src/compiler/Bytecode.zig
+++ b/src/compiler/Bytecode.zig
@@ -80,9 +80,9 @@ fn formatOpcode(self: Self, opcode: Opcode, operands: []const u8, writer: anytyp
             const const_idx = std.mem.readInt(u16, operands[0..2], .big);
             try writer.print(" {s}", .{self.constants[const_idx]});
         },
-        .list => {
-            const list_size = std.mem.readInt(u16, operands[0..2], .big);
-            try writer.print(" {d}", .{list_size});
+        .list, .dict => {
+            const size = std.mem.readInt(u16, operands[0..2], .big);
+            try writer.print(" {d}", .{size});
         },
         .jump, .jump_if_false, .loop => {
             const instr_idx = std.mem.readInt(u16, operands[0..2], .big);

--- a/src/compiler/opcodes.zig
+++ b/src/compiler/opcodes.zig
@@ -7,15 +7,17 @@ pub const Opcode = enum(u8) {
     @"const" = 0x01,
     /// The `list` opcode is used to create a list from the values on the stack.
     list = 0x02,
+    /// The `dict` opcode is used to create a dictionary from the values on the stack.
+    dict = 0x03,
     /// The `pop` opcode is used to pop a value from the stack.
-    pop = 0x03,
+    pop = 0x04,
     /// The `jump` opcode is used to jump to an instruction.
-    jump = 0x04,
+    jump = 0x05,
     /// The `jump_if_false` opcode is used to jump to an instruction if the top of the stack is false.
     /// The top of the stack is popped.
-    jump_if_false = 0x05,
+    jump_if_false = 0x06,
     /// The `loop` opcode is used to jump back `n` instructions.
-    loop = 0x06,
+    loop = 0x07,
     /// The `true` opcode is used to push a true value onto the stack.
     true = 0x10,
     /// The `false` opcode is used to push a false value onto the stack.
@@ -74,6 +76,8 @@ pub const Opcode = enum(u8) {
     set_index = 0x72,
     /// The `get_index` opcode is used to get the value of a list.
     get_index = 0x73,
+    /// The `declare_key` opcode is used to declare a key in a dictionary.
+    declare_key = 0x80,
 
     /// Converts the given opcode to a byte.
     pub fn byte(self: Opcode) u8 {
@@ -121,6 +125,7 @@ pub const Instruction = union(Opcode) {
     @"return": void,
     @"const": u16,
     list: u16,
+    dict: u16,
     pop: void,
     jump: u16,
     jump_if_false: u16,
@@ -154,6 +159,7 @@ pub const Instruction = union(Opcode) {
     get_local: u16,
     set_index: void,
     get_index: void,
+    declare_key: u16,
 
     pub fn opcode(self: Instruction) Opcode {
         return std.meta.stringToEnum(Opcode, @tagName(self)) orelse unreachable;

--- a/src/compiler/opcodes.zig
+++ b/src/compiler/opcodes.zig
@@ -76,6 +76,10 @@ pub const Opcode = enum(u8) {
     set_index = 0x72,
     /// The `get_index` opcode is used to get the value of a list.
     get_index = 0x73,
+    /// The `set_member` opcode is used to set the value of a member in a class/dictionary.
+    set_member = 0x74,
+    /// The `get_member` opcode is used to get the value of a member in a class/dictionary.
+    get_member = 0x75,
     /// The `declare_key` opcode is used to declare a key in a dictionary.
     declare_key = 0x80,
 
@@ -159,6 +163,8 @@ pub const Instruction = union(Opcode) {
     get_local: u16,
     set_index: void,
     get_index: void,
+    set_member: void,
+    get_member: void,
     declare_key: u16,
 
     pub fn opcode(self: Instruction) Opcode {

--- a/src/compiler/value.zig
+++ b/src/compiler/value.zig
@@ -208,9 +208,14 @@ pub const Value = union(enum) {
             .identifier => |value| try writer.print("{s}", .{value}),
             .list => |value| {
                 var iterator = value.iterator();
+
+                var index: usize = 0;
                 try writer.writeAll("[");
-                while (iterator.next()) |entry| {
+                while (iterator.next()) |entry| : (index += 1) {
                     try writer.print("{s}", .{entry.value_ptr});
+                    if (index < value.count() - 1) {
+                        try writer.writeAll(", ");
+                    }
                 }
                 try writer.writeAll("]");
             },

--- a/src/utils/cursor.zig
+++ b/src/utils/cursor.zig
@@ -23,6 +23,7 @@ pub fn Cursor(comptime T: type) type {
             return self.input[self.index];
         }
 
+        /// Returns true if the cursor can still read values.
         pub fn canRead(self: *Self) bool {
             return self.index < self.input.len;
         }
@@ -89,6 +90,11 @@ pub fn Cursor(comptime T: type) type {
 
         /// Returns a slice of the input from the current position to the given amount.
         pub fn peekSlice(self: *Self, amount: usize) []const T {
+            return self.input[self.index..(self.index + amount)];
+        }
+
+        pub fn peekSliceOrNull(self: *Self, amount: usize) ?[]const T {
+            if (self.index + amount > self.input.len) return null;
             return self.input[self.index..(self.index + amount)];
         }
 

--- a/src/utils/stack.zig
+++ b/src/utils/stack.zig
@@ -50,6 +50,14 @@ pub fn Stack(comptime T: type) type {
             return self.data.items[self.data.items.len - 1];
         }
 
+        /// Returns a pointer to the top value of the stack or an error if the stack is empty.
+        pub fn peekPtr(self: *Self) Error!*T {
+            if (self.data.items.len == 0) {
+                return Error.StackEmpty;
+            }
+            return &(self.data.items[self.data.items.len - 1]);
+        }
+
         /// Returns the value at the specified index.
         pub fn get(self: *Self, index: usize) Error!T {
             return self.data.items[index];

--- a/src/vm/Vm.zig
+++ b/src/vm/Vm.zig
@@ -536,6 +536,12 @@ fn freeValue(self: *Self, value: Value) void {
                 self.freeValue(entry.value_ptr.*);
             }
         },
+        .dict => |dict| {
+            var iterator = dict.iterator();
+            while (iterator.next()) |entry| {
+                self.freeValue(entry.value_ptr.*);
+            }
+        },
         .string => |_| {
             // todo: separate interned strings from reg strings
             // don't free if interned

--- a/src/vm/Vm.zig
+++ b/src/vm/Vm.zig
@@ -379,9 +379,7 @@ fn execute(self: *Self, instruction: Opcode) VmError!void {
                     const index: usize = @intFromFloat(index_value.number);
                     try self.pushOrError(value.list.get(index) orelse .null);
                 },
-                .dict => {
-                    try self.pushOrError(value.dict.get(index_value.string) orelse .null);
-                },
+                .dict => try self.pushOrError(value.dict.get(index_value.string) orelse .null),
                 inline else => {
                     self.diagnostics.report("Expected expression to be a list or dictionary but got {s}", .{value});
                     return VmError.GenericError;

--- a/tests/dict.hon
+++ b/tests/dict.hon
@@ -1,12 +1,4 @@
-let dict = { i: 0 };
+let dict = { a: { b: 1 } };
 
-for (0...10) |i| {
-    dict.i = i;
-}
-
-dict.new_key = 5;
-dict.nested = { a: 1, b: 2, c: 3 };
-
-@println("Dict: ", dict);
-@println("Dict.nonexistent: ", dict.nonexistent);
-@println("Dict.nested.a: ", dict.nested.a);
+dict.a.b = 2;
+@println(dict.a.b);

--- a/tests/dict.hon
+++ b/tests/dict.hon
@@ -1,0 +1,10 @@
+let dict = { i: 0 };
+
+for (0...10) |i| {
+    dict.i = i;
+}
+
+dict.new_key = 5;
+
+@println("Dict: ", dict);
+@println("Dict.nonexistent: ", dict.nonexistent);

--- a/tests/dict.hon
+++ b/tests/dict.hon
@@ -5,6 +5,8 @@ for (0...10) |i| {
 }
 
 dict.new_key = 5;
+dict.nested = { a: 1, b: 2, c: 3 };
 
 @println("Dict: ", dict);
 @println("Dict.nonexistent: ", dict.nonexistent);
+@println("Dict.nested.a: ", dict.nested.a);


### PR DESCRIPTION
# overview
Dictionaries are an essential language feature for every scripting language. This pull request aims to add basic support for dictionaries.

# examples
honey dictionaries support identifier & string-based keys like so:
```ts
const dict = { a: 1, "b": true, c: null, d: { e: 2 } };

// trailing commas are also supported
const dict_2 = { f: 5.1,  };
```
from here, dictionaries support both member access (e.g., dot-indexing) as well as bracket indexing like so:
```ts
const language = {
    name: "honey",
    version: "v0.1.0",
    description: "A small embeddable scripting language, built in Zig",
    prev_versions: {
        "v0.0.1": { description: "Initial release" },
    },
};

// name: "honey"
const name = language.name;
// version: v0.1.0
const version = language["version"];
// initial version: { description: "Initial release" }
const initial_version = language.prev_versions["v0.0.1"];
```

# other changes
- Add `@len` builtin for dictionaries, lists, and strings
```zig
const string = "test string";
const list = [0, 1, 2];
const dict = { "a": 1, "b": 2, "c": 3, d: 4};

// outputs "11, 3, 4"
@println(@len(string), ", ", @len(list), ", ", @len(dict));
```

# future changes
- operator support: we do not support any concatenation or multiplication of lists/dictionaries. these are niceties to have in a language
- support assignment variants: at the moment, only the assignment operator is supported for dictionaries & lists. we'll need to support all assignment variants (e.g., `+=`, `-=`, etc.)
