### PR TITLE
feat: parser error messages

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -10,7 +10,7 @@ pub fn build(b: *std.Build) void {
             .root_source_file = b.path("src/wasm.zig"),
             .target = target,
             .optimize = .ReleaseSmall,
-            .version = .{ .major = 0, .minor = 1, .patch = 0 },
+            .version = .{ .major = 0, .minor = 1, .patch = 1 },
         });
         // used to ensure exports
         lib.rdynamic = true;

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = "honey",
-    .version = "0.0.1",
+    .version = "0.1.1",
     .dependencies = .{
         .clap = .{
             .url = "https://github.com/Hejsil/zig-clap/archive/refs/tags/0.9.1.tar.gz",

--- a/src/honey.zig
+++ b/src/honey.zig
@@ -38,7 +38,7 @@ pub fn parse(source: Source, options: ParseOptions) !Result(ast.Program) {
         .file => |file| try file.handle.readToEndAlloc(arena.allocator(), std.math.maxInt(usize)),
     };
 
-    const lex_data = try tokenize(input, arena.allocator(), source.file.name);
+    const lex_data = try tokenize(input, arena.allocator(), if (source == .file) source.file.name else null);
 
     var parser = Parser.init(lex_data, .{
         .ally = arena.allocator(),

--- a/src/honey.zig
+++ b/src/honey.zig
@@ -7,7 +7,7 @@ pub const Compiler = @import("compiler/Compiler.zig");
 pub const Bytecode = @import("compiler/Bytecode.zig");
 pub const Vm = @import("vm/Vm.zig");
 
-pub const version = "0.0.1";
+pub const version = "0.1.1";
 
 pub fn tokenize(input: []const u8, allocator: std.mem.Allocator, source_name: ?[]const u8) Lexer.Data.Error!Lexer.Data {
     var lexer = Lexer.init(input, allocator, source_name);

--- a/src/lexer/Lexer.zig
+++ b/src/lexer/Lexer.zig
@@ -24,32 +24,86 @@ const KeywordMap = std.StaticStringMap(Token).initComptime(.{
     .{ "and", .@"and" },
 });
 
-const Self = @This();
+pub const Data = struct {
+    pub const Error = std.mem.Allocator.Error;
 
-/// A list of generated tokens from the lexer
-tokens: std.ArrayList(TokenData),
+    source: []const u8,
+    tokens: std.ArrayList(TokenData),
+    line_data: std.ArrayList(utils.Span),
+
+    pub fn init(ally: std.mem.Allocator, source: []const u8) Data {
+        return .{
+            .source = source,
+            .tokens = std.ArrayList(TokenData).init(ally),
+            .line_data = std.ArrayList(utils.Span).init(ally),
+        };
+    }
+
+    pub fn deinit(self: *Data) void {
+        self.tokens.deinit();
+        self.line_data.deinit();
+    }
+
+    pub fn addToken(self: *Data, token: TokenData) Error!void {
+        try self.tokens.append(token);
+    }
+
+    pub fn addLineData(self: *Data, datum: utils.Span) Error!void {
+        try self.line_data.append(datum);
+    }
+
+    /// Returns a slice of the source based on the line number provided
+    pub fn getLineByNum(self: *Data, line_no: usize) ?[]const u8 {
+        const line_index = line_no - 1;
+        // line index exceeds bounds. we *should* error here but a null is fine for now
+        if (line_index >= self.line_data.items.len) return null;
+
+        const line_data = self.line_data.items[line_index];
+        return self.source[line_data.start..line_data.end];
+    }
+
+    /// Returns a slice of the source based on the line data provided
+    pub fn getLineBySpan(self: *Data, line_data: utils.Span) []const u8 {
+        // todo: we should probably do error handling
+        return self.source[line_data.start..line_data.end];
+    }
+};
+
+const Self = @This();
+const NewLineSeparator = '\n';
+
+/// The allocator used to allocate the data from the lexer
+ally: std.mem.Allocator,
+/// The data accumulated from the lexer
+data: Data,
 /// The current position of the lexer
 cursor: utils.Cursor(u8),
+/// Where the current starting byte offset is
+start_byte_offset: usize = 0,
 
-pub fn init(input: []const u8, allocator: std.mem.Allocator) Self {
-    return .{ .tokens = std.ArrayList(TokenData).init(allocator), .cursor = utils.Cursor(u8).init(input) };
+pub fn init(input: []const u8, ally: std.mem.Allocator) Self {
+    return .{
+        .ally = ally,
+        .cursor = utils.Cursor(u8).init(input),
+        .data = Data.init(ally, input),
+    };
 }
 
 pub fn deinit(self: *Self) void {
-    self.tokens.deinit();
+    self.data.deinit();
 }
 
 /// Reads as many tokens as possible from the current position
-pub fn readAll(self: *Self) ![]const TokenData {
-    while (self.read()) |token| {
-        try self.tokens.append(token);
+pub fn readAll(self: *Self) Data.Error!Data {
+    while (try self.read()) |token| {
+        try self.data.addToken(token);
     }
-    return self.tokens.items;
+    return self.data;
 }
 
 /// Reads a single token from the current position or null if no token could be read
-pub fn read(self: *Self) ?TokenData {
-    self.skipWhitespace();
+pub fn read(self: *Self) Data.Error!?TokenData {
+    try self.skipWhitespace();
     if (!self.cursor.canRead()) {
         return null;
     }
@@ -72,9 +126,41 @@ pub fn read(self: *Self) ?TokenData {
     };
 }
 
+/// Returns true if the char is whitespace and
+fn isNonNewLineWhitespace(char: u8) bool {
+    return std.ascii.isWhitespace(char) and char != NewLineSeparator;
+}
+
 /// Skips all whitespace from the current position
-inline fn skipWhitespace(self: *Self) void {
-    _ = self.cursor.readWhile(std.ascii.isWhitespace);
+fn skipWhitespace(self: *Self) std.mem.Allocator.Error!void {
+    // i'd love to get rid of this (potential) infinite loop
+    // at the moment, it's here so that we can ensure we can
+    // add the last span to the list before we exit the loop
+    while (true) : (self.cursor.advance()) {
+        // if we encounter the end of the stream, add the last span and break
+        if (!self.cursor.canRead()) {
+            try self.createLineData();
+            break;
+        }
+
+        const current = self.cursor.current();
+        // break early if we encounter non-whitespace
+        if (!std.ascii.isWhitespace(current)) {
+            break;
+        }
+
+        // if we a new line, add a span to the list and advance the cursor
+        if (current == NewLineSeparator) {
+            try self.createLineData();
+        }
+    }
+}
+
+/// Creates a span from the Lexer's current `start_byte_offset` and the cursor's current index
+/// Has the side effect of updating `start_byte_offset` to the next cursor index
+fn createLineData(self: *Self) std.mem.Allocator.Error!void {
+    try self.data.addLineData(.{ .start = self.start_byte_offset, .end = self.cursor.index });
+    self.start_byte_offset = self.cursor.index + 1;
 }
 
 // Reads tokens from a map of characters to tokens or a fallback if no match was found
@@ -113,7 +199,7 @@ fn readComment(self: *Self) ?TokenData {
     }
     const data, const position = self.cursor.readUntil(struct {
         fn check(char: u8) bool {
-            return char == '\n';
+            return char == NewLineSeparator;
         }
     }.check);
     return TokenData.create(.{ .comment = std.mem.trim(u8, data, "/") }, position.start, position.end);
@@ -229,7 +315,7 @@ fn tokenizeAndExpect(input: []const u8, expected: []const TokenData) anyerror!vo
     var lexer = Self.init(input, std.testing.allocator);
     defer lexer.deinit();
     const parsed = try lexer.readAll();
-    try std.testing.expectEqualDeep(expected, parsed);
+    try std.testing.expectEqualDeep(expected, parsed.tokens.items);
 }
 
 test "test simple lexer" {

--- a/src/lexer/Lexer.zig
+++ b/src/lexer/Lexer.zig
@@ -26,6 +26,8 @@ const KeywordMap = std.StaticStringMap(Token).initComptime(.{
 
 pub const Data = struct {
     pub const Error = std.mem.Allocator.Error;
+    /// The default source name to use when none is provided
+    /// This happens primarily due to direct input or the playground
     const DefaultSourceName = "vm";
 
     source_name: []const u8,

--- a/src/lexer/token.zig
+++ b/src/lexer/token.zig
@@ -168,6 +168,10 @@ pub const Token = union(TokenTag) {
     pipe,
     invalid: u8,
 
+    pub fn tag(self: Token) TokenTag {
+        return std.meta.activeTag(self);
+    }
+
     pub fn format(self: Token, _: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {
         return switch (self) {
             .number => |value| try writer.print("{{ .number = \"{s}\" }}", .{value}),
@@ -203,7 +207,7 @@ pub const Token = union(TokenTag) {
 
 pub const TokenData = struct {
     token: Token,
-    position: utils.Position,
+    position: utils.Span,
 
     pub fn create(token: Token, start: usize, end: usize) TokenData {
         return .{

--- a/src/lexer/token.zig
+++ b/src/lexer/token.zig
@@ -110,6 +110,45 @@ pub const TokenTag = enum {
     pipe,
     /// .invalid represents an invalid character
     invalid,
+
+    pub fn name(self: TokenTag) []const u8 {
+        return switch (self) {
+            .equal => "==",
+            .not_equal => "!=",
+            .greater_than => ">",
+            .greater_than_equal => ">=",
+            .less_than => "<",
+            .less_than_equal => "<=",
+            .bang => "!",
+            .plus => "+",
+            .minus => "-",
+            .star => "*",
+            .slash => "/",
+            .modulo => "%",
+            .doublestar => "**",
+            .semicolon => ";",
+            .colon => ":",
+            .assignment => "=",
+            .plus_assignment => "+=",
+            .minus_assignment => "-=",
+            .star_assignment => "*=",
+            .slash_assignment => "/=",
+            .modulo_assignment => "%=",
+            .doublestar_assignment => "**=",
+            .comma => ",",
+            .left_paren => "(",
+            .right_paren => ")",
+            .left_bracket => "[",
+            .right_bracket => "]",
+            .left_brace => "{",
+            .right_brace => "}",
+            .dot => ".",
+            .exclusive_range => "..",
+            .inclusive_range => "...",
+            .pipe => "|",
+            inline else => @tagName(self),
+        };
+    }
 };
 
 pub const Token = union(TokenTag) {
@@ -174,19 +213,13 @@ pub const Token = union(TokenTag) {
 
     pub fn format(self: Token, _: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {
         return switch (self) {
-            .number => |value| try writer.print("{{ .number = \"{s}\" }}", .{value}),
-            .identifier => |value| try writer.print("{{ .identifier = \"{s}\" }}", .{value}),
-            .string => |value| try writer.print("{{ .string = \"{s}\" }}", .{value}),
-            .builtin => |value| try writer.print("{{ .builtin = \"{s}\" }}", .{value}),
-            .invalid => |value| try writer.print("{{ .invalid = '{c}' }}", .{value}),
-            .assignment => try writer.writeAll("="),
-            .plus_assignment => try writer.writeAll("+="),
-            .minus_assignment => try writer.writeAll("-="),
-            .star_assignment => try writer.writeAll("*="),
-            .slash_assignment => try writer.writeAll("/="),
-            .modulo_assignment => try writer.writeAll("%="),
-            .doublestar_assignment => try writer.writeAll("**="),
-            inline else => try writer.print(".{s}", .{@tagName(self)}),
+            .number => |value| try writer.print("{s}", .{value}),
+            .identifier => |value| try writer.print("{s}", .{value}),
+            .string => |value| try writer.print("\"{s}\"", .{value}),
+            .builtin => |value| try writer.print("{s}", .{value}),
+            .comment => |comment| try writer.print("// {s}", .{comment}),
+            .invalid => |value| try writer.print("'{c}'", .{value}),
+            inline else => try writer.print("{s}", .{self.tag().name()}),
         };
     }
 

--- a/src/lexer/token.zig
+++ b/src/lexer/token.zig
@@ -252,4 +252,9 @@ pub const TokenData = struct {
     pub fn format(self: TokenData, _: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {
         try writer.print("TokenData {{ .token = {s}, .position = {s} }}", .{ self.token, self.position });
     }
+
+    /// Returns a new `TokenData` with the position offset by `value`
+    pub fn offset(self: TokenData, value: isize) TokenData {
+        return .{ .token = self.token, .position = self.position.offset(value) };
+    }
 };

--- a/src/lexer/token.zig
+++ b/src/lexer/token.zig
@@ -255,6 +255,8 @@ pub const TokenData = struct {
 
     /// Returns a new `TokenData` with the position offset by `value`
     pub fn offset(self: TokenData, value: isize) TokenData {
-        return .{ .token = self.token, .position = self.position.offset(value) };
+        var cloned = self.position.clone();
+        _ = cloned.offset(value);
+        return .{ .token = self.token, .position = cloned };
     }
 };

--- a/src/lexer/token.zig
+++ b/src/lexer/token.zig
@@ -217,7 +217,7 @@ pub const Token = union(TokenTag) {
             .identifier => |value| try writer.print("{s}", .{value}),
             .string => |value| try writer.print("\"{s}\"", .{value}),
             .builtin => |value| try writer.print("{s}", .{value}),
-            .comment => |comment| try writer.print("// {s}", .{comment}),
+            .comment => |comment| try writer.print("//{s}", .{comment}),
             .invalid => |value| try writer.print("'{c}'", .{value}),
             inline else => try writer.print("{s}", .{self.tag().name()}),
         };

--- a/src/main.zig
+++ b/src/main.zig
@@ -78,7 +78,7 @@ pub fn main() !void {
 
     const result = try honey.run(input, .{
         .allocator = allocator,
-        .error_writer = std.io.getStdErr().writer(),
+        .error_writer = std.io.getStdErr().writer().any(),
         .dump_bytecode = res.args.@"dump-bytecode" == 1,
     });
     defer result.deinit();
@@ -102,7 +102,7 @@ fn runRepl(allocator: std.mem.Allocator) !void {
         // runInVm will print the error for us
         var result = honey.run(.{ .string = input }, .{
             .allocator = allocator,
-            .error_writer = std.io.getStdOut().writer(),
+            .error_writer = std.io.getStdOut().writer().any(),
         }) catch continue;
         defer result.deinit();
         if (result.data.getLastPopped()) |value| {

--- a/src/parser/Parser.zig
+++ b/src/parser/Parser.zig
@@ -595,7 +595,7 @@ fn parseExpressionAsPrefix(self: *Self) ParserError!Expression {
             break :blk parsed;
         },
         inline else => {
-            self.diagnostics.report("no prefix parse rule for token: {}", .{current.token}, self.cursor.current());
+            self.diagnostics.report("unable to parse '{s}' as prefix", .{current.token}, current);
             return ParserError.NoPrefixParseRule;
         },
     };
@@ -705,12 +705,12 @@ inline fn peekIs(self: *Self, tag: TokenTag) bool {
 /// Throws an error if the current token is not the expected tag.
 fn expectCurrentAndAdvance(self: *Self, tag: TokenTag) ParserError!void {
     if (!self.cursor.canRead()) {
-        self.diagnostics.report("expected current token: {} but got EOF", .{tag}, self.cursor.current());
+        self.diagnostics.report("expected '{s}' but got EOF", .{tag.name()}, self.cursor.current());
         return ParserError.UnexpectedEOF;
     }
     if (!self.currentIs(tag)) {
         // todo: we should
-        self.diagnostics.report("expected current token: {} but got: {}", .{ tag, self.currentToken() }, self.cursor.current());
+        self.diagnostics.report("expected '{s}' but got '{s}'", .{ tag.name(), self.currentToken() }, self.cursor.current());
         return ParserError.ExpectedCurrentMismatch;
     }
     self.cursor.advance();
@@ -718,12 +718,12 @@ fn expectCurrentAndAdvance(self: *Self, tag: TokenTag) ParserError!void {
 
 /// Throws an error if the current token is not the expected tag.
 fn expectPeekAndAdvance(self: *Self, tag: TokenTag) ParserError!void {
-    if (!self.cursor.canRead()) {
-        self.diagnostics.report("expected peek token: {} but got EOF", .{tag}, self.cursor.current());
+    const peek = self.cursor.peek() orelse {
+        self.diagnostics.report("expected token '{s}' but got EOF", .{tag.name()}, self.cursor.current());
         return ParserError.UnexpectedEOF;
-    }
+    };
     if (!self.peekIs(tag)) {
-        self.diagnostics.report("expected peek token: {} but got: {?}", .{ tag, self.peekToken() catch null }, self.cursor.current());
+        self.diagnostics.report("expected token: '{s}' but got '{s}'", .{ tag.name(), peek }, peek);
         return ParserError.ExpectedPeekMismatch;
     }
     self.cursor.advance();

--- a/src/parser/Parser.zig
+++ b/src/parser/Parser.zig
@@ -259,9 +259,16 @@ fn parseStatement(self: *Self, needs_terminated: bool) ParserError!?Statement {
             }
 
             var terminated: bool = false;
-            if (self.currentIs(.semicolon)) {
-                self.cursor.advance();
-                terminated = true;
+
+            switch (expression) {
+                .for_expr, .while_expr, .if_expr => if (self.currentIs(.semicolon)) {
+                    self.cursor.advance();
+                    terminated = true;
+                },
+                inline else => if (needs_terminated) {
+                    try self.expectSemicolon();
+                    terminated = true;
+                },
             }
             break :blk ast.createExpressionStatement(expression, terminated);
         },

--- a/src/parser/Parser.zig
+++ b/src/parser/Parser.zig
@@ -127,6 +127,7 @@ pub fn report(self: *Self) void {
         return;
     }
 
+    // todo: color!
     const msg_data = self.diagnostics.errors.items(.msg);
     const token_data = self.diagnostics.errors.items(.token_data);
     for (msg_data, token_data, 0..) |msg, token_datum, index| {

--- a/src/parser/Parser.zig
+++ b/src/parser/Parser.zig
@@ -179,7 +179,6 @@ pub fn printErrorAtToken(self: *Self, token_data: TokenData, msg: []const u8) !v
 
     const token_len = token_data.position.end - token_data.position.start;
     try self.error_writer.writeByteNTimes('~', token_len + 1);
-    try self.error_writer.writeByte('\n');
 }
 
 /// Parses the tokens into an AST.

--- a/src/parser/Parser.zig
+++ b/src/parser/Parser.zig
@@ -285,7 +285,7 @@ fn expectSemicolon(self: *Self) ParserError!void {
     const prev = self.cursor.previous().?;
     self.diagnostics.report("expected ';' after statement", .{}, .{
         .token = prev.token,
-        .position = .{ .start = prev.position.end + 1, .end = prev.position.end + 1 },
+        .position = prev.position.offset(1),
     });
     return ParserError.UnexpectedToken;
 }
@@ -704,7 +704,7 @@ inline fn peekIs(self: *Self, tag: TokenTag) bool {
 /// Throws an error if the current token is not the expected tag.
 fn expectCurrentAndAdvance(self: *Self, tag: TokenTag) ParserError!void {
     if (!self.cursor.canRead()) {
-        self.diagnostics.report("expected '{s}' but got EOF", .{tag.name()}, self.cursor.current());
+        self.diagnostics.report("expected '{s}' but got EOF", .{tag.name()}, self.cursor.previous().?);
         return ParserError.UnexpectedEOF;
     }
     if (!self.currentIs(tag)) {

--- a/src/parser/Parser.zig
+++ b/src/parser/Parser.zig
@@ -284,9 +284,14 @@ fn expectSemicolon(self: *Self) ParserError!void {
 
     // todo: is there a better way to implement this?
     const prev = self.cursor.previous().?;
+
+    var position = prev.position.clone();
+    _ = position.offset(1);
+    _ = position.moveToEnd();
     self.diagnostics.report("expected ';' after statement", .{}, .{
         .token = prev.token,
-        .position = prev.position.offset(1),
+        // offset by 1 and move
+        .position = position,
     });
     return ParserError.UnexpectedToken;
 }

--- a/src/parser/Parser.zig
+++ b/src/parser/Parser.zig
@@ -704,11 +704,11 @@ inline fn peekIs(self: *Self, tag: TokenTag) bool {
 /// Throws an error if the current token is not the expected tag.
 fn expectCurrentAndAdvance(self: *Self, tag: TokenTag) ParserError!void {
     if (!self.cursor.canRead()) {
-        self.diagnostics.report("expected '{s}' but got EOF", .{tag.name()}, self.cursor.previous().?);
+        // offset by one so it doesn't highlight the previous token
+        self.diagnostics.report("expected '{s}' but got EOF", .{tag.name()}, self.cursor.previous().?.offset(1));
         return ParserError.UnexpectedEOF;
     }
     if (!self.currentIs(tag)) {
-        // todo: we should
         self.diagnostics.report("expected '{s}' but got '{s}'", .{ tag.name(), self.currentToken() }, self.cursor.current());
         return ParserError.ExpectedCurrentMismatch;
     }
@@ -718,7 +718,8 @@ fn expectCurrentAndAdvance(self: *Self, tag: TokenTag) ParserError!void {
 /// Throws an error if the current token is not the expected tag.
 fn expectPeekAndAdvance(self: *Self, tag: TokenTag) ParserError!void {
     const peek = self.cursor.peek() orelse {
-        self.diagnostics.report("expected token '{s}' but got EOF", .{tag.name()}, self.cursor.current());
+        // offset by one so it doesn't highlight the current token
+        self.diagnostics.report("expected token '{s}' but got EOF", .{tag.name()}, self.cursor.current().offset(1));
         return ParserError.UnexpectedEOF;
     };
     if (!self.peekIs(tag)) {

--- a/src/utils/Diagnostics.zig
+++ b/src/utils/Diagnostics.zig
@@ -1,44 +1,45 @@
 const std = @import("std");
+const token = @import("../lexer/token.zig");
 
 const Self = @This();
+
+pub const ErrorData = struct {
+    msg: []const u8,
+    token_data: token.TokenData,
+};
 
 /// The allocator used for printing error messages
 ally: std.mem.Allocator,
 /// The last error message
-errors: std.ArrayList([]const u8),
+errors: std.MultiArrayList(ErrorData) = .{},
 
 pub fn init(ally: std.mem.Allocator) Self {
-    return .{ .ally = ally, .errors = std.ArrayList([]const u8).init(ally) };
+    return .{ .ally = ally };
 }
 
 /// Deinitializes the diagnostics
 pub fn deinit(self: *Self) void {
-    for (self.errors.items) |msg| {
+    for (self.errors.items(.msg)) |msg| {
         self.ally.free(msg);
     }
-    self.errors.deinit();
+    self.errors.deinit(self.ally);
 }
 
 /// Returns whether an error has been reported
 pub fn hasErrors(self: *Self) bool {
-    return self.errors.items.len > 0;
+    return self.errors.len > 0;
 }
 
 /// Returns the number of errors reported
 pub fn errorCount(self: *Self) usize {
-    return self.errors.items.len;
+    return self.errors.len;
 }
 
 /// Reports an error
-pub fn report(self: *Self, comptime fmt: []const u8, args: anytype) void {
-    const msg = std.fmt.allocPrint(self.ally, fmt, args) catch @panic("Failed to allocate error message");
-    self.errors.append(msg) catch @panic("Failed to append error message");
-}
-
-/// Dumps the error messages to the provided writer
-pub fn dump(self: *Self, writer: anytype) void {
-    writer.print("Errors ({d}):\n", .{self.errorCount()}) catch unreachable;
-    for (self.errors.items) |msg| {
-        writer.print("- {s}\n", .{msg}) catch unreachable;
-    }
+pub fn report(self: *Self, comptime fmt: []const u8, args: anytype, token_data: token.TokenData) void {
+    self.errors.append(self.ally, ErrorData{
+        // todo: errors over panics
+        .msg = std.fmt.allocPrint(self.ally, fmt, args) catch @panic("Failed to allocate error message"),
+        .token_data = token_data,
+    }) catch @panic("Failed to append error message");
 }

--- a/src/utils/Position.zig
+++ b/src/utils/Position.zig
@@ -1,9 +1,0 @@
-const std = @import("std");
-const Self = @This();
-
-start: usize,
-end: usize,
-
-pub fn format(self: Self, _: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {
-    try writer.print("{{ .start = {d}, .end = {d} }}", .{ self.start, self.end });
-}

--- a/src/utils/cursor.zig
+++ b/src/utils/cursor.zig
@@ -9,6 +9,22 @@ pub const Span = struct {
     pub fn format(self: Span, _: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {
         try writer.print("{{ .start = {d}, .end = {d} }}", .{ self.start, self.end });
     }
+
+    pub fn offset(self: Span, value: usize) Span {
+        return .{ .start = self.start + value, .end = self.end + value };
+    }
+
+    pub fn offsetStart(self: Span, value: usize) Span {
+        return .{ .start = self.start + value, .end = self.end };
+    }
+
+    pub fn offsetEnd(self: Span, value: usize) Span {
+        return .{ .start = self.start, .end = self.end + value };
+    }
+
+    pub fn offsetBoth(self: Span, start_offset: usize, end_offset: usize) Span {
+        return .{ .start = self.start + start_offset, .end = self.end + end_offset };
+    }
 };
 
 pub fn Cursor(comptime T: type) type {

--- a/src/utils/cursor.zig
+++ b/src/utils/cursor.zig
@@ -15,20 +15,41 @@ pub const Span = struct {
         return @intCast(@addWithOverflow(cast_base, offset_value).@"0");
     }
 
-    pub fn offset(self: Span, value: isize) Span {
-        return .{ .start = add(self.start, value), .end = add(self.end, value) };
+    /// Clones the span
+    pub fn clone(self: Span) Span {
+        return .{ .start = self.start, .end = self.end };
     }
 
-    pub fn offsetStart(self: Span, value: isize) Span {
-        return .{ .start = add(self.start, value), .end = self.end };
+    /// Returns the length of the span
+    pub fn len(self: Span) usize {
+        return self.end - self.start;
     }
 
-    pub fn offsetEnd(self: Span, value: isize) Span {
-        return .{ .start = self.start, .end = add(self.end, value) };
+    pub fn offset(self: *Span, value: isize) *Span {
+        self.start += add(self.start, value);
+        self.end = add(self.end, value);
+        return self;
     }
 
-    pub fn offsetBoth(self: Span, start_offset: isize, end_offset: isize) Span {
-        return .{ .start = add(self.start, start_offset), .end = add(self.end, end_offset) };
+    pub fn offsetStart(self: *Span, value: isize) *Span {
+        self.start += add(self.start, value);
+        return self;
+    }
+
+    pub fn offsetEnd(self: *Span, value: isize) *Span {
+        self.end = add(self.end, value);
+        return self;
+    }
+
+    pub fn offsetBoth(self: *Span, start_offset: isize, end_offset: isize) *Span {
+        self.start += add(self.start, start_offset);
+        self.end = add(self.end, end_offset);
+        return self;
+    }
+
+    pub fn moveToEnd(self: *Span) *Span {
+        self.start = self.end;
+        return self;
     }
 };
 

--- a/src/utils/cursor.zig
+++ b/src/utils/cursor.zig
@@ -1,10 +1,21 @@
-const Position = @import("Position.zig");
+const std = @import("std");
+
+pub const Span = struct {
+    /// The start of the span
+    start: usize,
+    /// The end of the span
+    end: usize,
+
+    pub fn format(self: Span, _: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {
+        try writer.print("{{ .start = {d}, .end = {d} }}", .{ self.start, self.end });
+    }
+};
 
 pub fn Cursor(comptime T: type) type {
     return struct {
         const Self = @This();
         const PredFn = *const fn (T) bool;
-        const ReadResult = struct { []const T, Position };
+        const ReadResult = struct { []const T, Span };
 
         input: []const T,
         index: usize,
@@ -93,9 +104,16 @@ pub fn Cursor(comptime T: type) type {
             return self.input[self.index..(self.index + amount)];
         }
 
+        /// Returns a slice of the input from the cursor position to the given amount
+        /// or null if the index + amount exceeds the bounds
         pub fn peekSliceOrNull(self: *Self, amount: usize) ?[]const T {
             if (self.index + amount > self.input.len) return null;
             return self.input[self.index..(self.index + amount)];
+        }
+
+        /// Slices the input given a start and end index
+        pub fn slice(self: *Self, start: usize, end: usize) []const T {
+            return self.input[start..end];
         }
 
         /// Returns true if the cursor is not at the end.

--- a/src/utils/cursor.zig
+++ b/src/utils/cursor.zig
@@ -10,20 +10,25 @@ pub const Span = struct {
         try writer.print("{{ .start = {d}, .end = {d} }}", .{ self.start, self.end });
     }
 
-    pub fn offset(self: Span, value: usize) Span {
-        return .{ .start = self.start + value, .end = self.end + value };
+    inline fn add(base: usize, offset_value: isize) usize {
+        const cast_base: isize = @intCast(base);
+        return @intCast(@addWithOverflow(cast_base, offset_value).@"0");
     }
 
-    pub fn offsetStart(self: Span, value: usize) Span {
-        return .{ .start = self.start + value, .end = self.end };
+    pub fn offset(self: Span, value: isize) Span {
+        return .{ .start = add(self.start, value), .end = add(self.end, value) };
     }
 
-    pub fn offsetEnd(self: Span, value: usize) Span {
-        return .{ .start = self.start, .end = self.end + value };
+    pub fn offsetStart(self: Span, value: isize) Span {
+        return .{ .start = add(self.start, value), .end = self.end };
     }
 
-    pub fn offsetBoth(self: Span, start_offset: usize, end_offset: usize) Span {
-        return .{ .start = self.start + start_offset, .end = self.end + end_offset };
+    pub fn offsetEnd(self: Span, value: isize) Span {
+        return .{ .start = self.start, .end = add(self.end, value) };
+    }
+
+    pub fn offsetBoth(self: Span, start_offset: isize, end_offset: isize) Span {
+        return .{ .start = add(self.start, start_offset), .end = add(self.end, end_offset) };
     }
 };
 

--- a/src/utils/utils.zig
+++ b/src/utils/utils.zig
@@ -1,8 +1,11 @@
 const std = @import("std");
 pub const bytes = @import("bytes.zig");
-pub const Cursor = @import("cursor.zig").Cursor;
+
+pub const cursor = @import("cursor.zig");
+pub const Cursor = cursor.Cursor;
+pub const Span = cursor.Span;
+
 pub const Diagnostics = @import("Diagnostics.zig");
-pub const Position = @import("Position.zig");
 pub const Repl = @import("Repl.zig");
 pub const Stack = @import("stack.zig").Stack;
 pub const Store = @import("store.zig").Store;

--- a/tests/dict.hon
+++ b/tests/dict.hon
@@ -4,12 +4,12 @@ const language = {
     description: "A small embeddable scripting language, built in Zig",
     versions: [
         { version: "v0.0.1", description: "Initial release" },
-        { version: "v0.1.0", description: "Added support for lists & dictionaries" ,
+        { version: "v0.1.0", description: "Added support for lists & dictionaries" },
     ],
 };
 
 // name: "honey"
-const name = language.name;
+const name = language.name
 // version: v0.1.0
 const version = language["version"];
 

--- a/tests/dict.hon
+++ b/tests/dict.hon
@@ -9,7 +9,7 @@ const language = {
 };
 
 // name: "honey"
-const name = language.name
+const name = language.name;
 // version: v0.1.0
 const version = language["version"];
 

--- a/tests/dict.hon
+++ b/tests/dict.hon
@@ -1,21 +1,4 @@
-const language = {
-    name: "honey",
-    version: "v0.1.0",
-    description: "A small embeddable scripting language, built in Zig",
-    versions: [
-        { version: "v0.0.1", description: "Initial release" },
-        { version: "v0.1.0", description: "Added support for lists & dictionaries" },
-    ],
-};
+const language = { name: "honey", version: "v0.1.0", }
 
-// name: "honey"
-const name = language.name;
-// version: v0.1.0
+const name = language.name
 const version = language["version"];
-
-@println("Honey ", version, " - ", name);
-@println("Description: ", language.description);
-@println("Versions:");
-for (language.versions) |version_data| {
-    @println(" - ", version_data.version, ": ", version_data.description, if (version_data.version == version) " (latest)" else "");
-}

--- a/tests/dict.hon
+++ b/tests/dict.hon
@@ -18,3 +18,4 @@ const version = language["version"];
 @println("Versions:");
 for (language.versions) |version_data| {
     @println(" - ", version_data.version, ": ", version_data.description, if (version_data.version == version) " (latest)" else "");
+}

--- a/tests/dict.hon
+++ b/tests/dict.hon
@@ -4,7 +4,7 @@ const language = {
     description: "A small embeddable scripting language, built in Zig",
     versions: [
         { version: "v0.0.1", description: "Initial release" },
-        { version: "v0.1.0", description: "Added support for lists & dictionaries" },
+        { version: "v0.1.0", description: "Added support for lists & dictionaries" ,
     ],
 };
 

--- a/tests/dict.hon
+++ b/tests/dict.hon
@@ -18,4 +18,3 @@ const version = language["version"];
 @println("Versions:");
 for (language.versions) |version_data| {
     @println(" - ", version_data.version, ": ", version_data.description, if (version_data.version == version) " (latest)" else "");
-}

--- a/tests/dict.hon
+++ b/tests/dict.hon
@@ -1,4 +1,21 @@
-const language = { name: "honey", version: "v0.1.0", }
+const language = {
+    name: "honey",
+    version: "v0.1.0",
+    description: "A small embeddable scripting language, built in Zig",
+    versions: [
+        { version: "v0.0.1", description: "Initial release" },
+        { version: "v0.1.0", description: "Added support for lists & dictionaries" },
+    ],
+};
 
-const name = language.name
+// name: "honey"
+const name = language.name;
+// version: v0.1.0
 const version = language["version"];
+
+@println("Honey ", version, " - ", name);
+@println("Description: ", language.description);
+@println("Versions:");
+for (language.versions) |version_data| {
+    @println(" - ", version_data.version, ": ", version_data.description, if (version_data.version == version) " (latest)" else "");
+}


### PR DESCRIPTION
# overview
Error messages are the lifeblood of debugging in every programming language. In a nutshell, they are both the UX and DX of the program. Good error messages can help a new user understand the syntax of the language. If absent, most would get easily frustrated and quit long before they hit their stride.

For most of its lifetime, honey was terrible at given any user feedback. This makes debugging both the user's source code and the language's source code a nightmare. Let's look at an easy example of how this pull request improves error messages.

# example
In the following example, there is a missing semicolon after both the `language` and `name` variables. This should be an *easy* report for any language to generate.
```zig
const language = { name: "honey", version: "v0.1.0", }

const name = language.name
const version = language["version"];
```

 However, before this pull request, the error messages given to the user would be:
```
Encountered the following errors during execution:
--------------------------------------------------
 - expected current token: lexer.token.TokenTag.semicolon but got: .const
 - expected current token: lexer.token.TokenTag.semicolon but got: .const
--------------------------------------------------
```
Ouch. That's not good. While it does give us mention something wanting a semicolon, it provides no line about where the issue is in the source code, nor does it show the user where it is expected to be. Furthermore, if you were debugging using CLI, it would barf the program's stack trace into the terminal for *no* reason.

After the pull request, the error messages have been improved to display the following:
```
[dict.hon:1:55] error: expected ';' after statement
        const language = { name: "honey", version: "v0.1.0", }
                                                              ~
[dict.hon:3:27] error: expected ';' after statement
        const name = language.name
                                  ~
```
*Much* better. Like most other languages, we report the file, column, & line, show a descriptive error message, and underline where the issue occurred. Furthermore, stack traces are no longer barfed onto the screen if we handled the errors already.

While this should've been a main priority in the language, I'm glad that it exists now.

# future changes
In the future, I would love to better enhance the messages by helping to guide them to the root of the issue. While good error messages can help users fix issues, great messages can help guide and address these issues at a faster pace.

Furthermore, I would love to add coloring to the terminal messages to better distinguish the parts of the error that are most important.

Lastly, these error messages only occur at a parser level. Compilation and execution will still need enhanced error messages for them to be useful.

# misc changes
* `Span`: Renamed from `Position` to `Span`
* `Span`: Added `offset` methods and `clone` method for moving around the source
* `TokenTag`: Added method `name` to get a string literal for the specified tag
* `Token`: Updated `format` logic to look more like the source rather than debug information
* writer: All structures (`Lexer`, `Parser`, `Compiler`, and `Vm`) now require `AnyWriter` rather than a `File.Writer`
* file: file names are now properly resolved and passed down into the `Source` structure

# bug fixes
* Fixed issue where dictionaries could omit the comma between entries
* Fixed issue where expressions could omit semicolons on the statement level
* Fixed issue in tests where the expected value didn't match the new compiled list instructions